### PR TITLE
Fix a couple "missing translation" errors

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -33,7 +33,7 @@
                 = link_to t('.settings'), settings_path
 
               %li
-                = link_to(t('logout'), destroy_user_session_path, method: :delete)
+                = link_to(t('.logout'), destroy_user_session_path, method: :delete)
 
 
     .container

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,9 +5,10 @@ en:
   hello: "Hello world"
 
   layouts:
-    application: "Welcome"
-    settings: "Settings"
-    logout: "Logout"
+    application:
+      welcome: "Welcome"
+      settings: "Settings"
+      logout: "Logout"
 
   devise:
     sessions:


### PR DESCRIPTION
This fixes a couple "missing translation" errors that appeared as `title` text when I hovered the pointer over certain elements on the home page.
